### PR TITLE
AFL Trace Path Problem

### DIFF
--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -114,7 +114,7 @@ class Fuzzer(object):
             # the path to AFL capable of calling driller
             self.afl_path         = shellphish_afl.afl_bin(self.os)
 
-            self.afl_path_var     = shellphish_afl.afl_path_var(self.os)
+            self.afl_path_var     = shellphish_afl.afl_path_var(p.arch.qemu_name)
 
             # set up libraries
             self._export_library_path(p)


### PR DESCRIPTION
Tracing wasn't working for me. The error was that the afl tracer path was incorrect, which appears to be right since it was being pointed to a directory that didn't exist (afl-unix/tracers/unix). The correct path seems to be afl-unix/tracers/i386 for example. Not sure the other implications of this change, but it seems to make fuzzer work for me.