### PR TITLE
Making QEMU optional

### DIFF
--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -21,7 +21,7 @@ class Fuzzer(object):
 
     def __init__(self, binary_path, work_dir, afl_count=1, library_path=None, time_limit=None,
             target_opts=None, extra_opts=None, create_dictionary=False,
-            seeds=None, crash_mode=False, never_resume=False):
+            seeds=None, crash_mode=False, never_resume=False, qemu=True):
         '''
         :param binary_path: path to the binary to fuzz. List or tuple for multi-CB.
         :param work_dir: the work directory which contains fuzzing jobs, our job directory will go here
@@ -33,6 +33,7 @@ class Fuzzer(object):
         :param extra_opts: extra options to pass to AFL when starting up
         :param crash_mode: if set to True AFL is set to crash explorer mode, and seed will be expected to be a crashing input
         :param never_resume: never resume an old fuzzing run, even if it's possible
+        :param qemu: Utilize QEMU for instrumentation of binary.
         '''
 
         self.binary_path    = binary_path
@@ -42,6 +43,7 @@ class Fuzzer(object):
         self.library_path   = library_path
         self.target_opts    = [ ] if target_opts is None else target_opts
         self.crash_mode     = crash_mode
+        self.qemu           = qemu
 
         Fuzzer._perform_env_checks()
 
@@ -433,7 +435,9 @@ class Fuzzer(object):
         args += ["-i", self.in_dir]
         args += ["-o", self.out_dir]
         args += ["-m", memory]
-        args += ["-Q"]
+
+        if self.qemu:
+            args += ["-Q"]
 
         if self.crash_mode:
             args += ["-C"]


### PR DESCRIPTION
Making QEMU utilization an option instead of forced. Still defaulting behavior to using it.

Open question on handling this in the future. You can tell if the binary is instrumented by checking for afl naming conventions (as I'm doing in autoPwn). It would make sense to do that in fuzzer and just have it default to the correct choice. Only problem is that it doesn't load up the project by default, and loading the project could add a decent load time overhead.

Interested in your thoughts on that tradeoff. For now, I'm fine controlling that choice from autoPwn. I would rather have the smarts be built into fuzzer though.