### PR TITLE
Piped through some more command line arguments

### DIFF
--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -64,7 +64,7 @@ class Fuzzer(object):
         self, binary_path, work_dir, afl_count=1, library_path=None, time_limit=None, memory="8G",
         target_opts=None, extra_opts=None, create_dictionary=False,
         seeds=None, crash_mode=False, never_resume=False, qemu=True, stuck_callback=None,
-        force_interval=None, job_dir=None
+        force_interval=None, job_dir=None, timeout=None
     ):
         '''
         :param binary_path: path to the binary to fuzz. List or tuple for multi-CB.
@@ -81,6 +81,7 @@ class Fuzzer(object):
         :param memory: AFL child process memory limit (default: "8G")
         :param stuck_callback: the callback to call when afl has no pending fav's
         :param job_dir: a job directory to override the work_dir/binary_name path
+        :param timeout: timeout for individual runs within AFL
         '''
 
         self.binary_path    = binary_path
@@ -93,6 +94,7 @@ class Fuzzer(object):
         self.memory         = memory
         self.qemu           = qemu
         self.force_interval = force_interval
+        self.timeout        = timeout
 
         Fuzzer._perform_env_checks()
 
@@ -529,6 +531,8 @@ class Fuzzer(object):
         # auto-calculate timeout based on the number of binaries
         if self.is_multicb:
             args += ["-t", "%d+" % (1000 * len(self.binary_path))]
+        elif self.timeout:
+            args += ["-t", "%d+" % self.timeout]
 
         args += ["--"]
         args += self.binary_path if self.is_multicb else [self.binary_path]

--- a/shellphuzz
+++ b/shellphuzz
@@ -26,8 +26,13 @@ if __name__ == "__main__":
     parser.add_argument('-i', '--ipython', help="Drop into ipython after starting the fuzzer.", action='store_true')
     parser.add_argument('-T', '--tarball', help="Tarball the resulting AFL workdir for further analysis to this file -- '{}' is replaced with the hostname.")
     parser.add_argument('-m', '--helper-module', help="A module that includes some helper scripts for seed selection and such.")
+    parser.add_argument('--memory', help="Memory limit to pass to AFL (MB, or use k, M, G, T suffixes)", default="8G")
     parser.add_argument('--no-dictionary', help="Do not create a dictionary before fuzzing.", action='store_true', default=False)
     parser.add_argument('--logcfg', help="The logging configuration file.", default=".shellphuzz.ini")
+    parser.add_argument('-s', '--seed-dir', action="append", help="Directory of files to seed fuzzer with")
+    parser.add_argument('--run-timeout', help="Number of seconds permitted for each run of binary", type=int)
+    parser.add_argument('--driller-timeout', help="Number of seconds to allow driller to run", type=int, default=10*60)
+    parser.add_argument('--length-extension', help="Try extending inputs to driller by this many bytes", type=int)
     args = parser.parse_args()
 
     if os.path.isfile(os.path.join(os.getcwd(), args.logcfg)):
@@ -56,44 +61,35 @@ if __name__ == "__main__":
         )
     if args.driller_workers:
         print "[*] Drilling..."
-        drill_extension = driller.LocalCallback(num_workers=args.driller_workers)
+        drill_extension = driller.LocalCallback(num_workers=args.driller_workers, worker_timeout=args.driller_timeout, length_extension=args.length_extension)
 
     stuck_callback = (
         (lambda f: (grease_extension(f), drill_extension(f))) if drill_extension and grease_extension
         else drill_extension or grease_extension
     )
 
+    seeds = None
+    if args.seed_dir:
+        seeds = []
+        print "[*] Seeding..."
+        for dirpath in args.seed_dir:
+            for filename in os.listdir(dirpath):
+                filepath = os.path.join(dirpath, filename)
+                if not os.path.isfile(filepath):
+                    continue
+                with open(filepath) as seedfile:
+                    seeds.append(seedfile.read())
+
     print "[*] Creating fuzzer..."
     fuzzer = fuzzer.Fuzzer(
         args.binary, args.work_dir, afl_count=args.afl_cores, force_interval=args.force_interval,
-        create_dictionary=not args.no_dictionary, stuck_callback=stuck_callback, time_limit=args.timeout
+        create_dictionary=not args.no_dictionary, stuck_callback=stuck_callback, time_limit=args.timeout,
+        memory=args.memory, seeds=seeds, timeout=args.run_timeout
     )
 
     # start it!
     print "[*] Starting fuzzer..."
     fuzzer.start()
-    start_time = time.time()
-
-    try:
-        if args.timeout or args.first_crash:
-            print "[*] Waiting for fuzzer completion (timeout: %s, first_crash: %s)." % (args.timeout, args.first_crash)
-
-            while True:
-                time.sleep(5)
-                if args.first_crash and fuzzer.found_crash():
-                    print "[*] Crash found!"
-                    break
-                if fuzzer.timed_out():
-                    print "[*] Timeout reached."
-                    break
-    except KeyboardInterrupt:
-        print "[*] Aborting wait. Ctrl-C again for KeyboardInterrupt."
-    except Exception as e:
-        print "[*] Unknown exception received (%s). Terminating fuzzer." % e
-        fuzzer.kill()
-        if drill_extension:
-            drill_extension.kill()
-        raise
 
     if args.ipython:
         print "[!]"
@@ -104,6 +100,29 @@ if __name__ == "__main__":
         print "[!] grease_extension"
         print "[!]"
         import IPython; IPython.embed()
+
+    try:
+        print "[*] Waiting for fuzzer completion (timeout: %s, first_crash: %s)." % (args.timeout, args.first_crash)
+
+        crash_seen = False
+        while True:
+            time.sleep(5)
+            if not crash_seen and fuzzer.found_crash():
+                print "[*] Crash found!"
+                crash_seen = True
+                if args.first_crash:
+                    break
+            if fuzzer.timed_out():
+                print "[*] Timeout reached."
+                break
+    except KeyboardInterrupt:
+        print "[*] Aborting wait. Ctrl-C again for KeyboardInterrupt."
+    except Exception as e:
+        print "[*] Unknown exception received (%s). Terminating fuzzer." % e
+        fuzzer.kill()
+        if drill_extension:
+            drill_extension.kill()
+        raise
 
     print "[*] Terminating fuzzer."
     fuzzer.kill()


### PR DESCRIPTION
* Ability to automatically extend length of inputs passed to driller (requires a PR in the driller repo to work)
* Ability to change the timeouts for AFL runs of the binary and driller runs
* Ability to change the memory limit
* Ability to use shellphuzz with neither first_crash nor timeout args
* Ability to seed shellphuzz with an existing directory of inputs