### PR TITLE
CFGFast now uses enable_indirect_jump_resolvers

### DIFF
--- a/bin/create_dict.py
+++ b/bin/create_dict.py
@@ -32,7 +32,7 @@ strcnt = itertools.count()
 def create(binary):
 
     b = angr.Project(binary, load_options={'auto_load_libs': False})
-    cfg = b.analyses.CFG(resolve_indirect_jumps=True, collect_data_references=True)
+    cfg = b.analyses.CFG(enable_indirect_jump_resolvers=True, collect_data_references=True)
 
     state = b.factory.blank_state()
 


### PR DESCRIPTION
See angr/angr#1103 @ltfish 