### PR TITLE
Pollenate should be wb

### DIFF
--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -462,7 +462,7 @@ class Fuzzer(object):
         pollen_cnt = len(os.listdir(nectary_queue_directory))
 
         for tcase in testcases:
-            with open(os.path.join(nectary_queue_directory, "id:%06d,src:pollenation" % pollen_cnt), "w") as f:
+            with open(os.path.join(nectary_queue_directory, "id:%06d,src:pollenation" % pollen_cnt), "wb") as f:
                 f.write(tcase)
 
             pollen_cnt += 1

--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -452,7 +452,7 @@ class Fuzzer(object):
         '''
         pollenate a fuzzing job with new testcases
 
-        :param testcases: list of strings representing new inputs to introduce
+        :param testcases: list of bytes objects representing new inputs to introduce
         '''
 
         nectary_queue_directory = os.path.join(self.out_dir, 'pollen', 'queue')


### PR DESCRIPTION
Since the migration to python3 for angr, pollenate should really write as `bytes` instead of `str`.